### PR TITLE
Fix for dot navigation not updating arrows

### DIFF
--- a/lib/stylie.slideshow.js
+++ b/lib/stylie.slideshow.js
@@ -334,7 +334,7 @@ StylieSlideshow.prototype._jump = function (position) {
 	this.isAnimating = true;
 	// update old and current values
 	this.old = this.current;
-	this.current = position;
+	this.current = parseInt(position, 10);
 	// slide
 	this._slide();
 };


### PR DESCRIPTION
The current slide position was being passed as a string but the nav toggle expected an int when clicking on the dot navigation. To duplicate click on the navigation dots for the first or last slide and notice that the navigation arrows will not toggle off.
